### PR TITLE
fix: 나의 정보 변경시 충돌 해결

### DIFF
--- a/ModuMoa/Models/Node.swift
+++ b/ModuMoa/Models/Node.swift
@@ -9,11 +9,7 @@ import Foundation
 import SwiftData
 
 @Model
-final class Node: Equatable, Identifiable {
-    static func == (lhs: Node, rhs: Node) -> Bool {
-        lhs.id == rhs.id
-    }
-    
+final class Node: Identifiable {
     @Attribute(.unique)
     let id: UUID = UUID()
     var level: Int
@@ -150,11 +146,16 @@ final class Node: Equatable, Identifiable {
     }
 }
 
+extension Node: Equatable {
+    static func == (lhs: Node, rhs: Node) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
 
 extension Node: Hashable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
-        hasher.combine(member)
     }
 }
 


### PR DESCRIPTION
나의 정보 변경 시 한번씩 fatal Error 가 나는 부분 수정하였습니다.

원인으로는 Equatable 을 충족하기 위해 정의한 == 함수와 Hashable 을 충족하기 위한 hash 함수에서 사용하는 프로퍼티가 달라 문제가 발생

해결 : hash 함수 재정의