### PR TITLE
refactor: children order feature

### DIFF
--- a/ModuMoa/ViewModels/HierarchyCardViewModel.swift
+++ b/ModuMoa/ViewModels/HierarchyCardViewModel.swift
@@ -23,6 +23,11 @@ final class HierarchyCardViewModel {
     var detailNodeViewIsPushed: Bool = false
     var fromMe: Bool = true
     var selectedNode: Node?
+    var orderedChildren: [Node] {
+        get {
+            node.children.sorted(by: { $0.member.birthday ?? Date() < $1.member.birthday ?? Date() })
+        }
+    }
     
     init(node: Node) {
         self.node = node

--- a/ModuMoa/ViewModels/RootViewModel.swift
+++ b/ModuMoa/ViewModels/RootViewModel.swift
@@ -113,7 +113,7 @@ final class RootViewModel {
     
     func setChildrenOfNode(_ node: Node) {
         if let partner = node.partner {
-            let children = Array(Set(node.children + partner.children).sorted(by: { $0.member.birthday ?? Date() <= $1.member.birthday ?? Date()}))
+            let children = Array(Set(node.children + partner.children))
             node.children = children
             partner.children = children
             if !children.isEmpty {

--- a/ModuMoa/Views/HierarchyCardView.swift
+++ b/ModuMoa/Views/HierarchyCardView.swift
@@ -36,7 +36,7 @@ struct HierarchyCardView: View {
             }
             
             HStack(alignment: .top, spacing: 80) {
-                ForEach(vm.node.children, id: \.id) { children in
+                ForEach(vm.orderedChildren, id: \.id) { children in
                     HierarchyCardView(node: children)
                 }
             }


### PR DESCRIPTION
자식 노드의 순서가 보장이 되지 않아, View 에서 사용시 sorted 된 프로퍼티를 사용할 수 있도록 변경