### PR TITLE
refactor: Coordinator 패턴 적용

### DIFF
--- a/ModuMoa.xcodeproj/project.pbxproj
+++ b/ModuMoa.xcodeproj/project.pbxproj
@@ -40,6 +40,10 @@
 		314C44862C4BBF8D0020FAA9 /* CaseOfAdd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314C44852C4BBF8D0020FAA9 /* CaseOfAdd.swift */; };
 		314C44882C4BC0B10020FAA9 /* MemberAddView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314C44872C4BC0B10020FAA9 /* MemberAddView.swift */; };
 		314FD6A62AE955CA0052251C /* InputNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314FD6A52AE955CA0052251C /* InputNameView.swift */; };
+		3157B11D2C881BEF00D8B38D /* ModumoaRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3157B11C2C881BEF00D8B38D /* ModumoaRouter.swift */; };
+		3157B11F2C8829E900D8B38D /* CardWithButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3157B11E2C8829E900D8B38D /* CardWithButtonView.swift */; };
+		3157B1222C8840F700D8B38D /* NavigationDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3157B1212C8840F700D8B38D /* NavigationDestination.swift */; };
+		3157B1242C88410100D8B38D /* FullScreenDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3157B1232C88410100D8B38D /* FullScreenDestination.swift */; };
 		317002BA2AD58B6100D8991A /* CGFloat+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317002B92AD58B6100D8991A /* CGFloat+.swift */; };
 		317328492C74AED000CB19EA /* EnvironmnetValues+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317328482C74AED000CB19EA /* EnvironmnetValues+.swift */; };
 		3173284B2C74B36D00CB19EA /* ViewSizePreferenceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3173284A2C74B36D00CB19EA /* ViewSizePreferenceKey.swift */; };
@@ -110,6 +114,10 @@
 		314C44852C4BBF8D0020FAA9 /* CaseOfAdd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaseOfAdd.swift; sourceTree = "<group>"; };
 		314C44872C4BC0B10020FAA9 /* MemberAddView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberAddView.swift; sourceTree = "<group>"; };
 		314FD6A52AE955CA0052251C /* InputNameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputNameView.swift; sourceTree = "<group>"; };
+		3157B11C2C881BEF00D8B38D /* ModumoaRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModumoaRouter.swift; sourceTree = "<group>"; };
+		3157B11E2C8829E900D8B38D /* CardWithButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardWithButtonView.swift; sourceTree = "<group>"; };
+		3157B1212C8840F700D8B38D /* NavigationDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationDestination.swift; sourceTree = "<group>"; };
+		3157B1232C88410100D8B38D /* FullScreenDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenDestination.swift; sourceTree = "<group>"; };
 		317002B92AD58B6100D8991A /* CGFloat+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGFloat+.swift"; sourceTree = "<group>"; };
 		317328482C74AED000CB19EA /* EnvironmnetValues+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmnetValues+.swift"; sourceTree = "<group>"; };
 		3173284A2C74B36D00CB19EA /* ViewSizePreferenceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewSizePreferenceKey.swift; sourceTree = "<group>"; };
@@ -178,6 +186,8 @@
 		310E88A22C4F88A900D5CB36 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				31B388EA2AE38E5000DFE875 /* CardView.swift */,
+				3157B11E2C8829E900D8B38D /* CardWithButtonView.swift */,
 				310E88A52C4F88E100D5CB36 /* ModumoaRoundedRectangleButton.swift */,
 				310E88A72C4F919D00D5CB36 /* ModumoaMemberSectionView.swift */,
 				310E88A92C4FADBC00D5CB36 /* SearchBarView.swift */,
@@ -210,6 +220,15 @@
 				3173284E2C74B8E800CB19EA /* DynamicHeightBottomSheetContentView.swift */,
 			);
 			path = Helpers;
+			sourceTree = "<group>";
+		};
+		3157B1202C8840E300D8B38D /* Router */ = {
+			isa = PBXGroup;
+			children = (
+				3157B1212C8840F700D8B38D /* NavigationDestination.swift */,
+				3157B1232C88410100D8B38D /* FullScreenDestination.swift */,
+			);
+			path = Router;
 			sourceTree = "<group>";
 		};
 		318457332AE94183007C2045 /* AddMyInformationViews */ = {
@@ -315,7 +334,6 @@
 				310E88A22C4F88A900D5CB36 /* Components */,
 				3185210F2AEEA300000579CE /* MemberViews */,
 				318457332AE94183007C2045 /* AddMyInformationViews */,
-				31B388EA2AE38E5000DFE875 /* CardView.swift */,
 				31B388EC2AE3944D00DFE875 /* HierarchyCardView.swift */,
 				310E88AB2C4FB3C200D5CB36 /* SearchView.swift */,
 			);
@@ -332,6 +350,7 @@
 				317A2E862C5B85D700C44280 /* MemberAddViewModel.swift */,
 				317A2E882C5B959800C44280 /* MemberDetailViewModel.swift */,
 				317A2E8A2C5B97AE00C44280 /* MemberUpdateViewModel.swift */,
+				3157B11C2C881BEF00D8B38D /* ModumoaRouter.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -339,6 +358,7 @@
 		A0F324CD2ADA7E7800D64198 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				3157B1202C8840E300D8B38D /* Router */,
 				A0F324CE2ADA7EB500D64198 /* Member.swift */,
 				A0F324D02ADA826200D64198 /* Node.swift */,
 				A06C1ABE2AF4BF9A001C8B4D /* RelationshipInfoType.swift */,
@@ -456,6 +476,7 @@
 				311A3EFC2AEE44800082D247 /* SelectBloodTypeView.swift in Sources */,
 				3185211A2AEFD93B000579CE /* MemberRhTypeView.swift in Sources */,
 				314C44822C494A980020FAA9 /* MemberUpdateView.swift in Sources */,
+				3157B11D2C881BEF00D8B38D /* ModumoaRouter.swift in Sources */,
 				3173284F2C74B8E800CB19EA /* DynamicHeightBottomSheetContentView.swift in Sources */,
 				A0F324CF2ADA7EB500D64198 /* Member.swift in Sources */,
 				314C447C2C4793050020FAA9 /* RoundedCorner.swift in Sources */,
@@ -464,6 +485,7 @@
 				318521182AEFD92C000579CE /* MemberBirthdayView.swift in Sources */,
 				3104A06D2C4D086A00DD8020 /* Line.swift in Sources */,
 				312A80172C5899A50079222D /* SideOfBaseNode.swift in Sources */,
+				3157B1222C8840F700D8B38D /* NavigationDestination.swift in Sources */,
 				314C44772C47653F0020FAA9 /* MemberFormView.swift in Sources */,
 				317328492C74AED000CB19EA /* EnvironmnetValues+.swift in Sources */,
 				314C44712C44F3270020FAA9 /* MemberDetailView.swift in Sources */,
@@ -472,6 +494,7 @@
 				310E889F2C4E7B6600D5CB36 /* CaseOfAddMyInformationView.swift in Sources */,
 				317002BA2AD58B6100D8991A /* CGFloat+.swift in Sources */,
 				31C70AA12C5FB58C001A13C5 /* DataHandler.swift in Sources */,
+				3157B11F2C8829E900D8B38D /* CardWithButtonView.swift in Sources */,
 				310E88B22C4FCBBB00D5CB36 /* UIViewController+.swift in Sources */,
 				31A78CA82AD42EE400BE629A /* ModuMoaApp.swift in Sources */,
 				317A2E8B2C5B97AE00C44280 /* MemberUpdateViewModel.swift in Sources */,
@@ -481,6 +504,7 @@
 				312A80132C57DD240079222D /* NicknameModeEnvironment.swift in Sources */,
 				3173284B2C74B36D00CB19EA /* ViewSizePreferenceKey.swift in Sources */,
 				314FD6A62AE955CA0052251C /* InputNameView.swift in Sources */,
+				3157B1242C88410100D8B38D /* FullScreenDestination.swift in Sources */,
 				31C70A9F2C5CC350001A13C5 /* UserDefatuls+.swift in Sources */,
 				31B388ED2AE3944D00DFE875 /* HierarchyCardView.swift in Sources */,
 				317A2E872C5B85D700C44280 /* MemberAddViewModel.swift in Sources */,

--- a/ModuMoa/Models/Router/FullScreenDestination.swift
+++ b/ModuMoa/Models/Router/FullScreenDestination.swift
@@ -1,0 +1,25 @@
+//
+//  FullScreenType.swift
+//  ModuMoa
+//
+//  Created by Sooik Kim on 9/4/24.
+//
+
+import SwiftUI
+
+enum FullScreenDestination: Hashable, Identifiable {
+    case updateNode(Node)
+    
+    var id: String {
+        String(describing: self)
+    }
+}
+
+extension FullScreenDestination {
+    @ViewBuilder func makeView() -> some View {
+        switch self {
+        case .updateNode(let node):
+            MemberUpdateView(node: node)
+        }
+    }
+}

--- a/ModuMoa/Models/Router/NavigationDestination.swift
+++ b/ModuMoa/Models/Router/NavigationDestination.swift
@@ -1,0 +1,28 @@
+//
+//  NavigationType.swift
+//  ModuMoa
+//
+//  Created by Sooik Kim on 9/4/24.
+//
+
+import SwiftUI
+
+enum NavigationDestination: Hashable {
+    case selectNode(Node)
+    case addNode(node: Node, caseOfAdd: CaseOfAdd?)
+    case serach
+}
+
+
+extension NavigationDestination {
+    @ViewBuilder func makeView() -> some View {
+        switch self {
+        case .selectNode(let node):
+            MemberDetailView(node: node)
+        case let .addNode(node, caseOfAdd):
+            MemberAddView(from: node, with: caseOfAdd)
+        case .serach:
+            SearchView()
+        }
+    }
+}

--- a/ModuMoa/ViewModels/HierarchyCardViewModel.swift
+++ b/ModuMoa/ViewModels/HierarchyCardViewModel.swift
@@ -10,19 +10,7 @@ import Foundation
 @Observable
 final class HierarchyCardViewModel {
     var node: Node
-    var isPresented: Bool = false
-    var selectedAddCase: CaseOfAdd?
-    var addNodeViewisPushed: Bool = false {
-        didSet {
-            if !addNodeViewisPushed {
-                selectedNode = nil
-                selectedAddCase = nil
-            }
-        }
-    }
-    var detailNodeViewIsPushed: Bool = false
-    var fromMe: Bool = true
-    var selectedNode: Node?
+    
     var orderedChildren: [Node] {
         get {
             node.children.sorted(by: { $0.member.birthday ?? Date() < $1.member.birthday ?? Date() })
@@ -32,25 +20,4 @@ final class HierarchyCardViewModel {
     init(node: Node) {
         self.node = node
     }
-    
-    func detailButtonTapped(_ node: Node) {
-        self.selectedNode = node
-        self.detailNodeViewIsPushed = true
-    }
-    
-    func plusButtonTapped(_ node: Node) {
-        self.selectedNode = node
-        self.isPresented = true
-    }
-    
-    func setSelectedAddCase(_ caseOfAdd: CaseOfAdd?) {
-        self.selectedAddCase = caseOfAdd
-    }
-    
-    func addButtonTapped() {
-        self.isPresented = false
-        self.addNodeViewisPushed = true
-    }
-    
-    
 }

--- a/ModuMoa/ViewModels/ModumoaRouter.swift
+++ b/ModuMoa/ViewModels/ModumoaRouter.swift
@@ -1,0 +1,47 @@
+//
+//  Coordinator.swift
+//  ModuMoa
+//
+//  Created by Sooik Kim on 9/4/24.
+//
+
+import SwiftUI
+import Observation
+
+protocol ModumoaRouterType {
+    var path: [NavigationDestination] { get set }
+    var fullScreenType: FullScreenDestination? { get set }
+    
+    func push(_ navigationType: NavigationDestination)
+    func pop()
+    func goToRoot()
+    func presentFullScreenCover(_ fullScreen: FullScreenDestination)
+    func dismissFullScreenCover()
+}
+
+@Observable
+final class ModumoaRouter: ModumoaRouterType {
+    
+    var path: [NavigationDestination] = []
+    var fullScreenType: FullScreenDestination?
+    
+    func push(_ destination: NavigationDestination) {
+        path.append(destination)
+    }
+    
+    func pop() {
+        let _ = path.removeLast()
+    }
+    
+    func goToRoot() {
+        path = []
+    }
+    
+    func presentFullScreenCover(_ destination: FullScreenDestination)  {
+        self.fullScreenType = destination
+    }
+    
+    func dismissFullScreenCover() {
+        self.fullScreenType = nil
+    }
+}

--- a/ModuMoa/ViewModels/SearchViewModel.swift
+++ b/ModuMoa/ViewModels/SearchViewModel.swift
@@ -12,8 +12,6 @@ import Observation
 final class SearchViewModel {
     var text: String = ""
     var nodes: [Node] = []
-    var selectedNode: Node?
-    var isPushed: Bool = false
     
     var filteredNodes: [Node] {
         self.nodes.filter({ $0.member.name.contains(self.text) || $0.member.nickNames.nickname.contains(self.text) })

--- a/ModuMoa/Views/Components/CardView.swift
+++ b/ModuMoa/Views/Components/CardView.swift
@@ -30,7 +30,6 @@ struct CardView: View {
                             Capsule().fill(.moduBlack)
                         }
                     }
-                    
             }
             .padding(.bottom, .betweenHeadlineAndTitle2)
             
@@ -54,8 +53,6 @@ struct CardView: View {
                     .foregroundStyle(.moduBlack)
             }
         }
-        
-        
     }
 }
 

--- a/ModuMoa/Views/Components/CardWithButtonView.swift
+++ b/ModuMoa/Views/Components/CardWithButtonView.swift
@@ -1,0 +1,98 @@
+//
+//  CardWithButtonView.swift
+//  ModuMoa
+//
+//  Created by Sooik Kim on 9/4/24.
+//
+
+import SwiftUI
+
+struct CardWithButtonView: View {
+    
+    @Environment(ModumoaRouter.self) var coordinator
+    @Environment(\.isNoSafeAreaDevice) var isNoSafeArea
+    
+    let node: Node
+    
+    @State private var selectedAddCase: CaseOfAdd?
+    @State private var isPresented: Bool = false
+    
+    var body: some View {
+        VStack {
+            CardView(member: node.member)
+                .onTapGesture {
+                    coordinator.push(.selectNode(node))
+                }
+            Button(action: {
+                isPresented = true
+            }, label: {
+                Image(systemName: "plus")
+                    .foregroundStyle(.white)
+                    .padding(4)
+                    .background{
+                        Circle()
+                            .fill(.disableText)
+                    }
+            })
+        }
+        .customDynamicHeightSheet($isPresented) {
+            halfSheetView()
+        }
+    }
+    
+    @ViewBuilder
+    private func halfSheetView() -> some View {
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 44) {
+                Text("추가하고 싶은 관계를 선택하세요")
+                    .font(.customFont(.headline))
+                    .foregroundStyle(.moduBlack)
+                
+                VStack(spacing: 16) {
+                    ForEach(CaseOfAdd.allCases, id: \.self) { addCase in
+                        let possible = node.member.nickNames.checkPossible(addCase)
+                        let isEnabled = addCase.canAddMember(node) && possible
+                        Button(action: {
+                            selectedAddCase = addCase
+                        }) {
+                            VStack(spacing: 16) {
+                                HStack {
+                                    let text = node.member.nickNames.nickname
+                                    Text("\(text)의 \(addCase.rawValue)")
+                                    Spacer()
+                                    if selectedAddCase == addCase {
+                                        Image(systemName: "checkmark")
+                                    }
+                                    if !isEnabled {
+                                        let reason = possible ? "이미 추가 됨" : "기능 추가 예정"
+                                        Text(reason)
+                                    }
+                                }
+                                .font(.customFont(.body))
+                                .foregroundStyle(isEnabled ? .moduBlack : .disableText)
+                                
+                                Divider()
+                                    .foregroundStyle(.disableLine)
+                            }
+                        }
+                        .disabled(!isEnabled)
+                    }
+                }
+            }
+            
+            Spacer()
+            
+            ModumoaRoundedRectangleButton("다음") {
+                isPresented = false
+                coordinator.push(.addNode(node: node, caseOfAdd: selectedAddCase))
+                selectedAddCase = nil
+            }
+            .disabled(selectedAddCase == nil)
+        }
+        .padding(.bottom, isNoSafeArea ? 16 : 0)
+    }
+}
+
+#Preview {
+    CardWithButtonView(node: .init(member: .init(name: "", bloodType: .init(abo: .A, rh: .negative), sex: .male)))
+}

--- a/ModuMoa/Views/HierarchyCardView.swift
+++ b/ModuMoa/Views/HierarchyCardView.swift
@@ -11,6 +11,7 @@ struct HierarchyCardView: View {
     
     @State private var vm: HierarchyCardViewModel
     @Environment(\.isNoSafeAreaDevice) var isNoSafeArea
+    @Environment(ModumoaRouter.self) var coordinator
     
     init(node: Node) {
         self._vm = .init(initialValue: .init(node: node))
@@ -21,14 +22,14 @@ struct HierarchyCardView: View {
     var body: some View {
         VStack(spacing: 80) {
             HStack(spacing: 20) {
-                cardViewWithButton(vm.node)
+                CardWithButtonView(node: vm.node)
                     .frame(width: 250)
                     .anchorPreference(key: Key.self, value: .center, transform: { anchor in
                         return [vm.node.id:anchor]
                     })
                 
                 if let partner = vm.node.partner {
-                    cardViewWithButton(partner)
+                    CardWithButtonView(node: partner)
                         .frame(width: 250)
                         .anchorPreference(key: Key.self, value: .center, transform: { anchor in
                             return [partner.id:anchor]
@@ -64,109 +65,12 @@ struct HierarchyCardView: View {
                 }
             }
         }
-        .customDynamicHeightSheet($vm.isPresented) {
-            halfSheetView()
-        }
-//        .customHalfSheet($vm.isPresented) {
-//            halfSheetView()
-//        }
-        .navigationDestination(isPresented: $vm.addNodeViewisPushed) {
-            if let unwrappedNode = Binding($vm.selectedNode) {
-                MemberAddView(from: unwrappedNode, with: $vm.selectedAddCase, isPushed: $vm.addNodeViewisPushed)
-            } else {
-                
-            }
-        }
-        .navigationDestination(isPresented: $vm.detailNodeViewIsPushed, destination: {
-            if let node = vm.selectedNode {
-                MemberDetailView(isPushed: $vm.detailNodeViewIsPushed, node: node)
-                    .onDisappear {
-                        vm.selectedNode = nil
-                    }
-            }
-        })
     }
     
     private func middleOfPoints(_ lhs: CGPoint, _ rhs: CGPoint) -> CGPoint {
         let x = (lhs.x + rhs.x) / 2
         let y = (lhs.y + rhs.y) / 2
         return CGPoint(x: x, y: y)
-    }
-    
-    @ViewBuilder
-    private func halfSheetView() -> some View {
-        if let fromNode = vm.selectedNode {
-            VStack(spacing: 0) {
-                VStack(alignment: .leading, spacing: 44) {
-                    Text("추가하고 싶은 관계를 선택하세요")
-                        .font(.customFont(.headline))
-                        .foregroundStyle(.moduBlack)
-                    
-                    VStack(spacing: 16) {
-                        ForEach(CaseOfAdd.allCases, id: \.self) { addCase in
-//                            let fromNode = vm.fromMe ? vm.node : vm.node.partner!
-                            let possible = fromNode.member.nickNames.checkPossible(addCase)
-                            let isEnabled = addCase.canAddMember(fromNode) && possible
-                            Button(action: {
-                                self.vm.setSelectedAddCase(addCase)
-                            }) {
-                                VStack(spacing: 16) {
-                                    HStack {
-                                        let text = fromNode.member.nickNames.nickname
-                                        Text("\(text)의 \(addCase.rawValue)")
-                                        Spacer()
-                                        if vm.selectedAddCase == addCase {
-                                            Image(systemName: "checkmark")
-                                        }
-                                        if !isEnabled {
-                                            let reason = possible ? "이미 추가 됨" : "기능 추가 예정"
-                                            Text(reason)
-                                        }
-                                    }
-                                    .font(.customFont(.body))
-                                    .foregroundStyle(isEnabled ? .moduBlack : .disableText)
-                                    
-                                    Divider()
-                                        .foregroundStyle(.disableLine)
-                                }
-                            }
-                            .disabled(!isEnabled)
-                        }
-                    }
-                }
-                
-                Spacer()
-                
-                ModumoaRoundedRectangleButton("다음") {
-                    self.vm.isPresented = false
-                    self.vm.addNodeViewisPushed = true
-                }
-                .disabled(vm.selectedAddCase == nil)
-            }
-            .padding(.bottom, isNoSafeArea ? 16 : 0)
-        }
-        
-    }
-    
-    @ViewBuilder
-    private func cardViewWithButton(_ node: Node) -> some View {
-        VStack {
-            CardView(member: node.member)
-                .onTapGesture {
-                    vm.detailButtonTapped(node)
-                }
-            Button(action: {
-                vm.plusButtonTapped(node)
-            }, label: {
-                Image(systemName: "plus")
-                    .foregroundStyle(.white)
-                    .padding(4)
-                    .background{
-                        Circle()
-                            .fill(.disableText)
-                    }
-            })
-        }
     }
 }
 

--- a/ModuMoa/Views/MemberViews/MemberAddView.swift
+++ b/ModuMoa/Views/MemberViews/MemberAddView.swift
@@ -10,20 +10,18 @@ import SwiftUI
 struct MemberAddView: View {
     
     @State private var vm: MemberAddViewModel
-    @Binding var isPushed: Bool
     @Environment(\.isNoSafeAreaDevice) var isNoSafeArea
+    @Environment(ModumoaRouter.self) var coordinator
     
-    init(from node: Binding<Node>, with selectedAddCase: Binding<CaseOfAdd?>, isPushed: Binding<Bool>) {
-        self._vm = .init(initialValue: .init(fromNode: node.wrappedValue, selectedAddCase: selectedAddCase.wrappedValue))
-        self._isPushed = isPushed
+    init(from node: Node, with selectedAddCase: CaseOfAdd?) {
+        self._vm = .init(initialValue: .init(fromNode: node, selectedAddCase: selectedAddCase))
     }
     
     var body: some View {
-        
         VStack(spacing: .betweenElements) {
             HStack {
                 Button(action: {
-                    isPushed = false
+                    coordinator.pop()
                 }) {
                     HStack {
                         Image(systemName: "chevron.left")
@@ -54,7 +52,7 @@ struct MemberAddView: View {
         Task {
             do {
                 try await vm.saveButtonTapped()
-                isPushed = false
+                coordinator.pop()
             } catch {
                 fatalError("error: \(error)")
             }

--- a/ModuMoa/Views/MemberViews/MemberDetailView.swift
+++ b/ModuMoa/Views/MemberViews/MemberDetailView.swift
@@ -10,12 +10,11 @@ import SwiftUI
 struct MemberDetailView: View {
     
     @Environment(\.nicknameMode) var nicknameMode
+    @Environment(ModumoaRouter.self) var coordinator
     
-    @Binding var isPushed: Bool
     @State private var vm: MemberDetailViewModel
     
-    init(isPushed: Binding<Bool>, node: Node) {
-        self._isPushed = isPushed
+    init(node: Node) {
         self.vm = .init(node: node)
     }
     
@@ -25,7 +24,7 @@ struct MemberDetailView: View {
             // MARK: Navigation Bar
             HStack {
                 Button(action: {
-                    isPushed = false
+                    coordinator.pop()
                 }) {
                     HStack(spacing: 4) {
                         Image(systemName: "chevron.left")
@@ -94,9 +93,6 @@ struct MemberDetailView: View {
             
             Spacer()
         }
-        .fullScreenCover(isPresented: $vm.isPresented, content: {
-            MemberUpdateView(node: vm.node, isPresented: $vm.isPresented)
-        })
         .transaction { transaction in
             transaction.disablesAnimations = true
         }
@@ -105,7 +101,7 @@ struct MemberDetailView: View {
                 HStack {
                     Spacer()
                     Button(action: {
-                        vm.updateButtonTapped()
+                        coordinator.presentFullScreenCover(.updateNode(vm.node))
                     }) {
                         Image(systemName: "pencil")
                     }

--- a/ModuMoa/Views/MemberViews/MemberUpdateView.swift
+++ b/ModuMoa/Views/MemberViews/MemberUpdateView.swift
@@ -10,13 +10,12 @@ import SwiftUI
 struct MemberUpdateView: View {
     
     @Environment(\.nicknameMode) var nicknameMode
+    @Environment(ModumoaRouter.self) var coordinator
     
-    @Binding var isPresented: Bool
     @State private var vm: MemberUpdateViewModel
     
-    init(node: Node, isPresented: Binding<Bool>) {
+    init(node: Node) {
         self._vm = .init(initialValue: .init(node: node))
-        self._isPresented = isPresented
     }
     
     var body: some View {
@@ -25,7 +24,7 @@ struct MemberUpdateView: View {
             // MARK: Navigation Bar
             HStack {
                 Button(action: {
-                    isPresented = false
+                    coordinator.dismissFullScreenCover()
                 }) {
                     Text("닫기")
                 }
@@ -53,7 +52,7 @@ struct MemberUpdateView: View {
         Task {
             do {
                 try await vm.saveButtonTapped()
-                isPresented = false
+                coordinator.dismissFullScreenCover()
             } catch {
                 fatalError("error: \(error)")
             }

--- a/ModuMoa/Views/SearchView.swift
+++ b/ModuMoa/Views/SearchView.swift
@@ -10,14 +10,14 @@ import SwiftUI
 struct SearchView: View {
     
     @State private var viewModel: SearchViewModel = SearchViewModel()
-    @Binding var isPushed: Bool
     @State private var isFocused: Bool = false
+    @Environment(ModumoaRouter.self) var coordinator
     
     var body: some View {
         VStack(spacing: .betweenTitleAndContent) {
             HStack {
                 Button(action: {
-                    isPushed = false
+                    coordinator.pop()
                 }) {
                     Image(systemName: "chevron.left")
                         .font(.customFont(.body))
@@ -54,8 +54,7 @@ struct SearchView: View {
                             ForEach(viewModel.filteredNodes) { node in
                                 CardView(member: node.member)
                                     .onTapGesture {
-                                        viewModel.selectedNode = node
-                                        viewModel.isPushed = true
+                                        coordinator.push(.selectNode(node))
                                     }
                             }
                         }
@@ -76,14 +75,10 @@ struct SearchView: View {
             isFocused = false
         }
         .navigationBarBackButtonHidden()
-        .navigationDestination(isPresented: $viewModel.isPushed) {
-            if let node = viewModel.selectedNode {
-                MemberDetailView(isPushed: $viewModel.isPushed, node: node)
-            }
-        }
     }
 }
 
 #Preview {
-    SearchView(isPushed: .constant(true))
+    SearchView()
+        .environment(ModumoaRouter())
 }


### PR DESCRIPTION
1. 작업 내용

- ModumoaRouter 를 정의하여 FullScreenCover, NaviagationDestination 을 Environment 로 한 ViewModel 에서 관리

3. 이유

- 확장성 고려

4. 효과

- 각 ViewModel 에서 불필요하게 된 selected Item, present 요소(변수 및 함수)를 삭제
- View 전화 용이
- GoToRoot 가능